### PR TITLE
Allow Customized Line-Separator Character

### DIFF
--- a/lib/file/tail.rb
+++ b/lib/file/tail.rb
@@ -102,11 +102,7 @@ class File
     def forward(n = 0)
       rewind
       while n > 0 and not eof?
-        if line_separator
-          readline(line_separator)
-        else
-          readline
-        end
+        readline(@line_separator)
         n -= 1
       end
       self
@@ -185,11 +181,7 @@ class File
           redo
         rescue ReopenException => e
           until eof? || @n == 0
-            if line_separator
-              block.call readline(line_separator)
-            else
-              block.call readline
-            end
+            block.call readline(@line_separator)
             @n -= 1 if @n
           end
           reopen_file(e.mode)
@@ -205,11 +197,7 @@ class File
     def read_line(&block)
       if @n
         until @n == 0
-          if line_separator
-            block.call readline(line_separator)
-          else
-            block.call readline
-          end
+          block.call readline(@line_separator)
           @lines   += 1
           @no_read = 0
           @n       -= 1
@@ -217,11 +205,7 @@ class File
         end
         raise ReturnException
       else
-        if line_separator
-          block.call readline(line_separator)
-        else
-          block.call readline
-        end
+        block.call readline(@line_separator)
         @lines   += 1
         @no_read = 0
         output_debug_information
@@ -243,6 +227,7 @@ class File
       @break_if_eof         = false if @break_if_eof.nil?
       @return_if_eof        = false if @return_if_eof.nil?
       @max_interval         ||= 10
+      @line_separator       ||= "$/"
       @interval             ||= @max_interval
       @suspicious_interval  ||= 60
       @lines                = 0

--- a/lib/file/tail.rb
+++ b/lib/file/tail.rb
@@ -100,6 +100,7 @@ class File
     # Skip the first <code>n</code> lines of this file. The default is to don't
     # skip any lines at all and start at the beginning of this file.
     def forward(n = 0)
+      preset_attributes unless @lines
       rewind
       while n > 0 and not eof?
         readline(@line_separator)
@@ -118,6 +119,7 @@ class File
     # filesystem this file belongs to or 8192 bytes if this cannot
     # be determined.
     def backward(n = 0, bufsize = nil)
+      preset_attributes unless @lines
       if n <= 0
         seek(0, File::SEEK_END)
         return self
@@ -131,13 +133,13 @@ class File
             start = tell
             seek(-bufsize, File::SEEK_CUR)
             buffer = read(bufsize)
-            n -= buffer.count("\n")
+            n -= buffer.count(@line_separator)
             seek(-bufsize, File::SEEK_CUR)
           end
         else
           rewind
           buffer = read(size)
-          n -= buffer.count("\n")
+          n -= buffer.count(@line_separator)
           rewind
         end
       rescue Errno::EINVAL
@@ -146,7 +148,7 @@ class File
       end
       pos = -1
       while n < 0  # forward if we are too far back
-        pos = buffer.index("\n", pos + 1)
+        pos = buffer.index(@line_separator, pos + 1)
         n += 1
       end
       seek(pos + 1, File::SEEK_CUR)

--- a/lib/file/tail.rb
+++ b/lib/file/tail.rb
@@ -227,7 +227,7 @@ class File
       @break_if_eof         = false if @break_if_eof.nil?
       @return_if_eof        = false if @return_if_eof.nil?
       @max_interval         ||= 10
-      @line_separator       ||= "$/"
+      @line_separator       ||= $/
       @interval             ||= @max_interval
       @suspicious_interval  ||= 60
       @lines                = 0

--- a/lib/file/tail.rb
+++ b/lib/file/tail.rb
@@ -103,7 +103,7 @@ class File
       rewind
       while n > 0 and not eof?
         if line_separator
-          readline(:sep => line_separator)
+          readline(line_separator)
         else
           readline
         end
@@ -186,7 +186,7 @@ class File
         rescue ReopenException => e
           until eof? || @n == 0
             if line_separator
-              block.call readline(:sep => line_separator)
+              block.call readline(line_separator)
             else
               block.call readline
             end
@@ -206,7 +206,7 @@ class File
       if @n
         until @n == 0
           if line_separator
-            block.call readline(:sep => line_separator)
+            block.call readline(line_separator)
           else
             block.call readline
           end
@@ -218,7 +218,7 @@ class File
         raise ReturnException
       else
         if line_separator
-          block.call readline(:sep => line_separator)
+          block.call readline(line_separator)
         else
           block.call readline
         end


### PR DESCRIPTION
We use the FFmpeg utility as part of our transcoding pipeline; it outputs many useful metrics like decode frame-rate, bitrate, and more.  The problem is that FFmpeg outputs a carriage-return character (\r) instead of a carriage-return-line-feed (\n) each time it writes these metrics.

In order to parse the FFmpeg metrics with file-tail, we needed to specify a different line-separate character (\r).  This pull-request adds the ability to customize the line-separator when instantiating a file-tail instance.

Example:
```ruby
File::Tail::Logfile.tail(log_path, 
                         :backward => 10,
                         :return_if_eof => false,
                         :line_separator => "\r") do |line|
...
end
```
