### PR TITLE
upgrade tins to ~> 1.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ GemHadar do
   ignore      '.*.sw[pon]', 'pkg', 'Gemfile.lock', 'coverage', '*.rbc', '.rbx'
   readme      'README.rdoc'
 
-  dependency  'tins', '~>0.5'
+  dependency  'tins', '~>1.0'
 
   development_dependency 'test-unit', '~>2.4.0'
 

--- a/file-tail.gemspec
+++ b/file-tail.gemspec
@@ -24,15 +24,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<gem_hadar>, ["~> 0.1.8"])
       s.add_development_dependency(%q<test-unit>, ["~> 2.4.0"])
-      s.add_runtime_dependency(%q<tins>, ["~> 0.5"])
+      s.add_runtime_dependency(%q<tins>, ["~> 1.0"])
     else
       s.add_dependency(%q<gem_hadar>, ["~> 0.1.8"])
       s.add_dependency(%q<test-unit>, ["~> 2.4.0"])
-      s.add_dependency(%q<tins>, ["~> 0.5"])
+      s.add_dependency(%q<tins>, ["~> 1.0"])
     end
   else
     s.add_dependency(%q<gem_hadar>, ["~> 0.1.8"])
     s.add_dependency(%q<test-unit>, ["~> 2.4.0"])
-    s.add_dependency(%q<tins>, ["~> 0.5"])
+    s.add_dependency(%q<tins>, ["~> 1.0"])
   end
 end


### PR DESCRIPTION
Hey most of your other libs depend on tins ~> 1.0 this is lagging behind and prevents me from using with other the libs in the same project. Ran tests and they all pass.

Looks like I'm not the only one who submitted a pull request with this change. Are you requiring older ruby 1.8.7 support?
