### PR TITLE
[master] should update @stat=stat even if @stat is existing

### DIFF
--- a/lib/file/tail.rb
+++ b/lib/file/tail.rb
@@ -247,9 +247,8 @@ class File
           @stat = nil
           raise ReopenException.new(:top)
         end
-      else
-        @stat = stat
       end
+      @stat = stat
     rescue Errno::ENOENT, Errno::ESTALE
       raise ReopenException
     end


### PR DESCRIPTION
I encounted the situation as below:
file-tail is tailing the system.log, at the beginning, the @stat.size is 0, while system.log became large, the @stat.size is still 0. after logrotate copytruncate
the system.log. file-tail readline and throw a EOF, the restat method
doesn't trigger the ReopenException because the @stat is 0.